### PR TITLE
Embed growth plot (README + site), fix badge, repair HuggingFace sync

### DIFF
--- a/.github/workflows/sync-to-hf.yml
+++ b/.github/workflows/sync-to-hf.yml
@@ -20,12 +20,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Push to HuggingFace
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Upload the README (the dataset card) via huggingface_hub instead of a raw
+      # `git push`. HuggingFace rejects binary files (e.g. the growth-plot PNG)
+      # pushed over plain git; the README references images by absolute URL, so
+      # they render on the Hub without uploading any binaries.
+      - name: Sync README to the HuggingFace dataset card
+        env:
+          HF_TOKEN: ${{ secrets.PARODI_HF_TOKEN }}
         run: |
-          git push --force https://fparodi:${{ secrets.PARODI_HF_TOKEN }}@huggingface.co/datasets/fparodi/awesome-computational-primatology main
+          pip install --quiet "huggingface_hub>=0.25"
+          python - <<'PY'
+          import os
+          from huggingface_hub import HfApi
+          HfApi(token=os.environ["HF_TOKEN"]).upload_file(
+              path_or_fileobj="README.md",
+              path_in_repo="README.md",
+              repo_id="fparodi/awesome-computational-primatology",
+              repo_type="dataset",
+              commit_message="Sync README from GitHub",
+          )
+          print("Synced README.md to the HuggingFace dataset.")
+          PY
 
       - name: Create issue on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # [Awesome Computational Primatology](https://kordinglab.com/awesome-computational-primatology/)
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-[![Papers](https://img.shields.io/badge/Papers-90-blue)](https://github.com/KordingLab/awesome-computational-primatology#projects)
+[![Papers](https://img.shields.io/badge/Papers-96-blue)](https://github.com/KordingLab/awesome-computational-primatology#projects)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/KordingLab/awesome-computational-primatology/blob/main/CONTRIBUTING.md)
 [![Last Updated](https://img.shields.io/github/last-commit/KordingLab/awesome-computational-primatology?label=last%20updated)](https://github.com/KordingLab/awesome-computational-primatology/commits/main)
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/KordingLab/awesome-computational-primatology/main/docs/assets/paper_growth_xkcd.png" alt="Computational primatology papers per year: this curated list vs. the broader 'primate + ML' literature" width="680"><br>
+  <sub><i>Papers per year — this hand-curated list (left) vs. the raw "primate + ML" literature on OpenAlex (right).</i></sub>
+</p>
 
 This repository contains the corpus of projects at the intersection of deep learning and **non-human** primatology since around the time AlexNet was published (~2012). This repo is intended for papers that provide novel approaches or applications in computational primatology. We occasionally include datasets which contain both primate and non-primate animals. Contributions and edits welcome!
 

--- a/index.html
+++ b/index.html
@@ -714,6 +714,7 @@
                     <span><strong id="with-code">20</strong> with code</span>
                     <span><strong id="with-data">24</strong> with data</span>
                 </div>
+                <img class="growth-plot" src="https://raw.githubusercontent.com/KordingLab/awesome-computational-primatology/main/docs/assets/paper_growth_xkcd.png" alt="Computational primatology papers per year: this curated list vs. the broader 'primate + ML' literature" style="max-width: 720px; width: 100%; margin: 1.25rem auto 0; display: block;">
             </div>
 
             <details class="legend">

--- a/scripts/website_generator.py
+++ b/scripts/website_generator.py
@@ -786,6 +786,7 @@ def get_enhanced_html_template() -> str:
                     <span><strong id="with-code">{with_code}</strong> with code</span>
                     <span><strong id="with-data">{with_data}</strong> with data</span>
                 </div>
+                <img class="growth-plot" src="https://raw.githubusercontent.com/KordingLab/awesome-computational-primatology/main/docs/assets/paper_growth_xkcd.png" alt="Computational primatology papers per year: this curated list vs. the broader 'primate + ML' literature" style="max-width: 720px; width: 100%; margin: 1.25rem auto 0; display: block;">
             </div>
 
             <details class="legend">


### PR DESCRIPTION
Addresses three things:

1. **Embed the growth plot** under the README title *and* in the website header — referenced by absolute raw-GitHub URL so it renders on GitHub, the Pages site, and the HF dataset card.
2. **Fix the Papers badge** (90 → 96) — it drifted after the scout added 6 papers.
3. **Repair the HuggingFace sync** — it has failed on every push since the plot was added, because HF rejects binary files (`docs/assets/paper_growth_xkcd.png`) pushed over plain `git push`. Switched to `huggingface_hub.upload_file` for the README dataset card (no binaries pushed; image renders via the absolute URL).

⚠️ Follow-ups (not in this PR): the MacaquePose / "Labuguen et al. 2019" rows are likely the same paper (de-dupe); and the badge will drift again as the scout adds papers — could auto-bump it in the scout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)