### PR TITLE
scout: auto-maintain the paper-count badge

### DIFF
--- a/scripts/scout/propose.py
+++ b/scripts/scout/propose.py
@@ -47,6 +47,11 @@ def make_row(candidate: Candidate) -> str:
     )
 
 
+def set_badge(readme_text: str, count: int) -> str:
+    """Update the "Papers-N" shields.io badge in the README to the given count."""
+    return re.sub(r"(badge/Papers-)\d+(-blue)", rf"\g<1>{count}\g<2>", readme_text)
+
+
 def insert_rows(readme_text: str, rows: list[str]) -> str:
     """Insert new rows at the top of the Projects table (newest-first convention)."""
     if not rows:

--- a/scripts/scout/run.py
+++ b/scripts/scout/run.py
@@ -99,6 +99,7 @@ def main() -> None:
 
     readme = propose.README_PATH.read_text(encoding="utf-8")
     readme = propose.insert_rows(readme, [propose.make_row(c) for c in keeps])
+    readme = propose.set_badge(readme, len(index) + len(keeps))  # keep the count badge current
     by_name = {e.name: e for e in index}
     for c in updates:
         if c.update_target in by_name:

--- a/tests/scout/test_scout.py
+++ b/tests/scout/test_scout.py
@@ -162,6 +162,12 @@ def test_make_row_format():
     assert row == "| 2026 | [X](https://doi.org/10.1/x) | FR | Macaque | N/A | N/A | 3,385 images |"
 
 
+def test_set_badge_updates_count():
+    text = "[![Papers](https://img.shields.io/badge/Papers-90-blue)](#projects)"
+    assert "Papers-96-blue" in propose.set_badge(text, 96)
+    assert "Papers-90" not in propose.set_badge(text, 96)
+
+
 def test_insert_rows_after_separator():
     readme = "### Projects\n\n| Year | Paper |\n|------|-------|\n| 2025 | old |\n"
     out = propose.insert_rows(readme, ["| 2026 | new |"])


### PR DESCRIPTION
Closes the badge-drift loop: the scout now updates the `Papers-N` badge to the new total whenever it adds rows, so it stays correct hands-off (this is why it read 90 instead of 96 earlier). +1 unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)